### PR TITLE
Step9/예외처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'org.slf4j:slf4j-api:2.0.16'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui
 //    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'

--- a/src/main/java/com/hhplus/commerce/common/exception/CommerceException.java
+++ b/src/main/java/com/hhplus/commerce/common/exception/CommerceException.java
@@ -1,0 +1,14 @@
+package com.hhplus.commerce.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class CommerceException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private ErrorInfo errorInfo;
+
+}

--- a/src/main/java/com/hhplus/commerce/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/common/exception/CommonErrorCode.java
@@ -1,0 +1,25 @@
+package com.hhplus.commerce.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "resource not found"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "Method not allowed"),
+    CONFLICT(HttpStatus.CONFLICT, "conflict request"),
+
+
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Invalid input value"),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+
+}

--- a/src/main/java/com/hhplus/commerce/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/common/exception/CommonErrorCode.java
@@ -11,6 +11,7 @@ public enum CommonErrorCode implements ErrorCode {
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "resource not found"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "Method not allowed"),
+    METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "Method argument not valid"),
     CONFLICT(HttpStatus.CONFLICT, "conflict request"),
 
 

--- a/src/main/java/com/hhplus/commerce/common/exception/CommonErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/common/exception/CommonErrorCode.java
@@ -15,7 +15,7 @@ public enum CommonErrorCode implements ErrorCode {
 
 
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Invalid input value"),
-
+    UNDEFINED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Undefined error"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/hhplus/commerce/common/exception/CustomException.java
+++ b/src/main/java/com/hhplus/commerce/common/exception/CustomException.java
@@ -7,8 +7,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 @AllArgsConstructor
-public class CommerceException extends RuntimeException {
+public class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
     private ErrorInfo errorInfo;
-
 }

--- a/src/main/java/com/hhplus/commerce/common/exception/ErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/common/exception/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.hhplus.commerce.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String name(); // enum에 기본적으로 존재하는 메소드
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/hhplus/commerce/common/exception/ErrorInfo.java
+++ b/src/main/java/com/hhplus/commerce/common/exception/ErrorInfo.java
@@ -1,0 +1,22 @@
+package com.hhplus.commerce.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorInfo {
+    private Map<String, Object> details = new HashMap<>();
+
+    public ErrorInfo addDetail(String key, Object value) {
+        details.put(key, value);
+        return this;
+    }
+
+    public Object getDetail(String key) {
+        return details.get(key);
+    }
+}

--- a/src/main/java/com/hhplus/commerce/common/exception/ErrorInfo.java
+++ b/src/main/java/com/hhplus/commerce/common/exception/ErrorInfo.java
@@ -11,6 +11,11 @@ import java.util.Map;
 public class ErrorInfo {
     private Map<String, Object> details = new HashMap<>();
 
+    // 빌더 호출 메소드
+    public static ErrorInfoBuilder builder() {
+        return new ErrorInfoBuilder();
+    }
+
     public ErrorInfo addDetail(String key, Object value) {
         details.put(key, value);
         return this;
@@ -18,5 +23,23 @@ public class ErrorInfo {
 
     public Object getDetail(String key) {
         return details.get(key);
+    }
+
+    // 빌더 클래스
+    public static class ErrorInfoBuilder {
+        private final Map<String, Object> details = new HashMap<>();
+
+        // 빌더 메소드로 필드 추가
+        public ErrorInfoBuilder addDetail(String key, Object value) {
+            details.put(key, value);
+            return this;
+        }
+
+        // 빌드 메소드
+        public ErrorInfo build() {
+            ErrorInfo errorInfo = new ErrorInfo();
+            errorInfo.details.putAll(details);
+            return errorInfo;
+        }
     }
 }

--- a/src/main/java/com/hhplus/commerce/common/exception/ErrorResponse.java
+++ b/src/main/java/com/hhplus/commerce/common/exception/ErrorResponse.java
@@ -1,7 +1,19 @@
 package com.hhplus.commerce.common.exception;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
 @Schema(description = "에러 응답")
-public record ErrorResponse(String errorCode, String message, String detail) {
+public class ErrorResponse {
+    private final String errorCode;
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Object details;
 }

--- a/src/main/java/com/hhplus/commerce/domain/account/AccountController.java
+++ b/src/main/java/com/hhplus/commerce/domain/account/AccountController.java
@@ -3,6 +3,7 @@ package com.hhplus.commerce.domain.account;
 import com.hhplus.commerce.domain.account.dto.AccountDepositRequest;
 import com.hhplus.commerce.domain.account.dto.AccountResponse;
 import com.hhplus.commerce.domain.account.entity.Account;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,19 +15,18 @@ public class AccountController {
 
     final private AccountService accountService;
 
-    @GetMapping(value = "/{productId}")
-    public ResponseEntity<AccountResponse> getAccount(@PathVariable Long id) {
+    @GetMapping(value = "/{accountId}")
+    public ResponseEntity<AccountResponse> getAccount(@PathVariable Long accountId) {
 
-//        AccountResponse accountResponse = new AccountResponse(productId, 10000L);
-        AccountResponse accountResponse = new AccountResponse(accountService.getAccountInfo(id));
+
+        AccountResponse accountResponse = new AccountResponse(accountService.getAccountInfo(accountId));
         return ResponseEntity.ok(accountResponse);
     }
 
     @PostMapping(value = "/deposit")
-    public ResponseEntity<AccountResponse> deposit(@RequestBody AccountDepositRequest request) {
+    public ResponseEntity<AccountResponse> deposit(@RequestBody @Valid AccountDepositRequest request) {
         Account account = accountService.deposit(request.accountId(), request.amount());
         AccountResponse accountResponse = new AccountResponse(account);
         return ResponseEntity.ok(accountResponse);
     }
-
 }

--- a/src/main/java/com/hhplus/commerce/domain/account/dto/AccountRequest.java
+++ b/src/main/java/com/hhplus/commerce/domain/account/dto/AccountRequest.java
@@ -1,7 +1,10 @@
 package com.hhplus.commerce.domain.account.dto;
 
-public record AccountRequest(Long id) {
-    public static AccountRequest of(Long id) {
+import jakarta.validation.constraints.NotNull;
+
+public record AccountRequest(@NotNull Long id) {
+
+    public static AccountRequest of(@NotNull Long id) {
         return new AccountRequest(id);
     }
 }

--- a/src/main/java/com/hhplus/commerce/domain/account/model/AccountErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/domain/account/model/AccountErrorCode.java
@@ -1,0 +1,17 @@
+package com.hhplus.commerce.domain.account.model;
+
+import com.hhplus.commerce.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AccountErrorCode implements ErrorCode {
+    ACCOUNT_NOT_EXIST(HttpStatus.NOT_FOUND, "Account does not exist"),
+    BALANCE_NOT_ENOUGH(HttpStatus.CONFLICT, "Balance is not enough"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/hhplus/commerce/domain/cart/model/CartErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/domain/cart/model/CartErrorCode.java
@@ -1,0 +1,15 @@
+package com.hhplus.commerce.domain.cart.model;
+
+import com.hhplus.commerce.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CartErrorCode implements ErrorCode {
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter included"),
+    ;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/hhplus/commerce/domain/order/OrderController.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/OrderController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -50,7 +51,7 @@ public class OrderController {
             @ApiResponse(responseCode = "500", description = "주문 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping(value = "/")
-    public ResponseEntity<OrderResponse> postOrder(@RequestBody OrderRequest orderRequest) {
+    public ResponseEntity<OrderResponse> postOrder(@RequestBody @Valid OrderRequest orderRequest) {
 //        OrderResponse orderResponse = new OrderResponse(productId, 1L, null, null, null, 0L, null);
         // REVIEW - orderService에 orderItemRequest (DTO)를 넘거주는 것이 찝찝합니다.
         // orderItem이라는 Entity를 넣으려고 하니 Product를 매핑해놓아 매번 새 Product 객체를 만들어서 넣는 것도 찝찝합니다.

--- a/src/main/java/com/hhplus/commerce/domain/order/dto/OrderItemRequest.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/dto/OrderItemRequest.java
@@ -1,7 +1,9 @@
 package com.hhplus.commerce.domain.order.dto;
 
-public record OrderItemRequest(Long productId, Long quantity) {
-    public static OrderItemRequest of(long productId, long quantity) {
+import jakarta.validation.constraints.NotNull;
+
+public record OrderItemRequest(@NotNull Long productId, @NotNull Long quantity) {
+    public static OrderItemRequest of(Long productId, Long quantity) {
         return new OrderItemRequest(productId, quantity);
     }
 }

--- a/src/main/java/com/hhplus/commerce/domain/order/dto/OrderRequest.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/dto/OrderRequest.java
@@ -1,8 +1,10 @@
 package com.hhplus.commerce.domain.order.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 import java.util.List;
 
-public record OrderRequest(Long accountId, List<OrderItemRequest> orderItems) {
+public record OrderRequest(@NotNull Long accountId, @NotNull List<OrderItemRequest> orderItems) {
 
     public static OrderRequest of(Long accountId, List<OrderItemRequest> orderItems) {
         return new OrderRequest(accountId, orderItems);

--- a/src/main/java/com/hhplus/commerce/domain/order/model/OrderErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/domain/order/model/OrderErrorCode.java
@@ -1,0 +1,18 @@
+package com.hhplus.commerce.domain.order.model;
+
+import com.hhplus.commerce.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode implements ErrorCode {
+    ORDER_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Order failed"),
+    STOCK_FAILURE(HttpStatus.CONFLICT, "Stock failure"),
+    PAYMENT_FAILED(HttpStatus.CONFLICT, "Payment failed"),
+    ALREADY_ORDERED(HttpStatus.CONFLICT, "Already ordered"),
+    ;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/hhplus/commerce/domain/product/ProductController.java
+++ b/src/main/java/com/hhplus/commerce/domain/product/ProductController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -38,7 +40,7 @@ public class ProductController {
             @ApiResponse(responseCode = "500", description = "상품 정보 조회 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping(value = "/{productId}")
-    public ResponseEntity<ProductStockResponse> getProductWithStock(@PathVariable Long productId) {
+    public ResponseEntity<ProductStockResponse> getProductWithStock(@PathVariable @Positive Long productId) {
         Stock stock = stockService.getStockByProductId(productId);
         return ResponseEntity.ok(new ProductStockResponse(stock));
     }
@@ -53,7 +55,7 @@ public class ProductController {
             @ApiResponse(responseCode = "500", description = "주문 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PostMapping(value = "/{productId}/orders")
-    public ResponseEntity<ProductOrderResponse> order(@PathVariable Long id, @RequestBody ProductOrderRequest productOrderRequest) {
+    public ResponseEntity<ProductOrderResponse> order(@PathVariable Long id, @RequestBody @Valid ProductOrderRequest productOrderRequest) {
         ProductOrderResponse productOrderResponse = new ProductOrderResponse(id, productOrderRequest.userId(), productOrderRequest.quantity());
         return ResponseEntity.ok(productOrderResponse);
     }

--- a/src/main/java/com/hhplus/commerce/domain/product/dto/ProductOrderRequest.java
+++ b/src/main/java/com/hhplus/commerce/domain/product/dto/ProductOrderRequest.java
@@ -1,4 +1,7 @@
 package com.hhplus.commerce.domain.product.dto;
 
-public record ProductOrderRequest(Long userId, int quantity) {
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record ProductOrderRequest(@NotNull Long userId, @NotNull @PositiveOrZero Integer quantity) {
 }

--- a/src/main/java/com/hhplus/commerce/domain/product/model/ProductErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/domain/product/model/ProductErrorCode.java
@@ -1,0 +1,16 @@
+package com.hhplus.commerce.domain.product.model;
+
+import com.hhplus.commerce.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorCode implements ErrorCode {
+    PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "Product not found"),
+    PRODUCT_NOT_FOR_SALE(HttpStatus.CONFLICT, "Product is not for sale"),
+    ;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/hhplus/commerce/domain/stock/model/StockErrorCode.java
+++ b/src/main/java/com/hhplus/commerce/domain/stock/model/StockErrorCode.java
@@ -1,0 +1,16 @@
+package com.hhplus.commerce.domain.stock.model;
+
+import com.hhplus.commerce.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum StockErrorCode implements ErrorCode {
+    STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "Stock not found"),
+    NOT_ENOUGH_STOCK(HttpStatus.CONFLICT, "Not enough stock"),
+    ;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/hhplus/commerce/globals/GlobalExceptionHandler.java
+++ b/src/main/java/com/hhplus/commerce/globals/GlobalExceptionHandler.java
@@ -1,0 +1,73 @@
+package com.hhplus.commerce.globals;
+
+import com.hhplus.commerce.common.exception.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return handleError(CommonErrorCode.UNDEFINED_ERROR);
+    }
+
+    // 표준 에러를 처리하는 핸들러
+    @ExceptionHandler(value = IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleError(errorCode);
+    }
+//    FIXME Ambiguous @ExceptionHandler method mapped
+//    @ExceptionHandler(value = NoHandlerFoundException.class)
+//    public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
+//        ErrorCode errorCode = CommonErrorCode.RESOURCE_NOT_FOUND;
+//        return handleError(errorCode);
+//    }
+
+//    FIXME Ambiguous @ExceptionHandler method mapped
+//    @ExceptionHandler(value = HttpRequestMethodNotSupportedException.class)
+//    public ResponseEntity<ErrorResponse> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
+//        ErrorCode errorCode = CommonErrorCode.METHOD_NOT_ALLOWED;
+//        ErrorInfo errorInfo = ErrorInfo.builder()
+//                .addDetail("method", e.getMethod())
+//                .addDetail("supportedMethods", e.getSupportedHttpMethods())
+//                .build();
+//
+//        return handleError(errorCode, errorInfo);
+//    }
+
+
+    // 서비스 로직에서 발생하는 예외를 처리하는 핸들러
+    @ExceptionHandler(value = CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        return handleError(e.getErrorCode(), e.getErrorInfo());
+    }
+
+    private ResponseEntity<ErrorResponse> handleError(ErrorCode errorCode, ErrorInfo errorInfo) {
+        ErrorResponse errorResponse = makeErrorResponse(errorCode, errorInfo);
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+    }
+
+    private ResponseEntity<ErrorResponse> handleError(ErrorCode errorCode) {
+        ErrorResponse errorResponse = makeErrorResponse(errorCode);
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+    }
+
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode, ErrorInfo errorInfo) {
+        if (errorInfo == null) {
+            return makeErrorResponse(errorCode);
+        }
+
+        return new ErrorResponse(errorCode.name(), errorCode.getMessage(), errorInfo.getDetails());
+    }
+
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.name(), errorCode.getMessage(), null);
+    }
+
+
+}

--- a/src/main/java/com/hhplus/commerce/globals/GlobalExceptionHandler.java
+++ b/src/main/java/com/hhplus/commerce/globals/GlobalExceptionHandler.java
@@ -1,11 +1,15 @@
 package com.hhplus.commerce.globals;
 
 import com.hhplus.commerce.common.exception.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
@@ -24,32 +28,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return handleError(errorCode);
     }
 
-//    FIXME Ambiguous @ExceptionHandler method mapped
-//    @ExceptionHandler(value = MethodArgumentNotValidException.class)
-//    @Override
-//    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e, HttpHeaders headers, HttpStatus status, WebRequest request) {
-//        return handleError(CommonErrorCode.METHOD_ARGUMENT_NOT_VALID, e);
-//    }
-
-//    FIXME Ambiguous @ExceptionHandler method mapped
-//    @ExceptionHandler(value = NoHandlerFoundException.class)
-//    public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
-//        ErrorCode errorCode = CommonErrorCode.RESOURCE_NOT_FOUND;
-//        return handleError(errorCode);
-//    }
-
-//    FIXME Ambiguous @ExceptionHandler method mapped
-//    @ExceptionHandler(value = HttpRequestMethodNotSupportedException.class)
-//    public ResponseEntity<ErrorResponse> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
-//        ErrorCode errorCode = CommonErrorCode.METHOD_NOT_ALLOWED;
-//        ErrorInfo errorInfo = ErrorInfo.builder()
-//                .addDetail("method", e.getMethod())
-//                .addDetail("supportedMethods", e.getSupportedHttpMethods())
-//                .build();
-//
-//        return handleError(errorCode, errorInfo);
-//    }
-
+    // NOTE @ExceptionHandler 어노테이션 안을 지워도 ambigous 오류가 발생하여 그냥 오버라이딩해버림
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return handleError(CommonErrorCode.METHOD_ARGUMENT_NOT_VALID, ex);
+    }
 
     // 서비스 로직에서 발생하는 예외를 처리하는 핸들러
     @ExceptionHandler(value = CustomException.class)

--- a/src/test/java/com/hhplus/commerce/domain/account/AccountIntegrationTest.java
+++ b/src/test/java/com/hhplus/commerce/domain/account/AccountIntegrationTest.java
@@ -2,6 +2,7 @@ package com.hhplus.commerce.domain.account;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hhplus.commerce.domain.account.dto.AccountDepositRequest;
+import com.hhplus.commerce.domain.account.dto.AccountRequest;
 import com.hhplus.commerce.domain.account.dto.AccountResponse;
 import com.hhplus.commerce.domain.account.entity.Account;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +35,23 @@ public class AccountIntegrationTest {
     @BeforeEach
     public void setUp() {
         accountRepository.insert(new Account());
+    }
+
+
+    @Test
+    public void 계좌_API_유효하지_않은_입력_테스트() throws Exception {
+        // Given
+        AccountDepositRequest request = new AccountDepositRequest(null, null);
+        AccountRequest accountRequest = AccountRequest.of(null);
+
+        // When
+        MockHttpServletResponse response = mockMvc.perform(post("/api/v1/accounts/deposit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andReturn().getResponse();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
 

--- a/src/test/java/com/hhplus/commerce/domain/order/OrderIntegrationTest.java
+++ b/src/test/java/com/hhplus/commerce/domain/order/OrderIntegrationTest.java
@@ -68,6 +68,21 @@ public class OrderIntegrationTest {
     }
 
 
+    @Test
+    public void API_잘못된_파라미터_테스트() throws Exception {
+        // Given
+        OrderRequest request = OrderRequest.of(null, null);
+
+        // When
+        MockHttpServletResponse response = mockMvc.perform(post(BASE_URL + "/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andReturn().getResponse();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
     @DisplayName("주문 정보 조회 테스트")
     @Test
     public void testGetOrderInfo() throws Exception {

--- a/src/test/java/com/hhplus/commerce/domain/product/ProductIntegrationTest.java
+++ b/src/test/java/com/hhplus/commerce/domain/product/ProductIntegrationTest.java
@@ -44,6 +44,22 @@ public class ProductIntegrationTest {
     }
 
 
+    @Test
+    public void API_잘못된_파라미터_테스트() throws Exception {
+        // Given
+        Long productId = 0L;
+
+        // When
+        MockHttpServletResponse response = mockMvc.perform(get(BASE_URL + "/" + productId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+
+    }
+
+
     @DisplayName("상품 정보 조회 테스트")
     @Test
     public void testGetProductInfo() throws Exception {


### PR DESCRIPTION
### [ 요약 ]
서비스 사용 중 발생할 수 있는 에러를 핸들링하는 기능 추가

### [ 세부내용 ]

**에러 정의**

- errorCode 인터페이스추가
- 에러코드별 enum으로 관리
- customException 클래스 추가. errorCode를 가짐
- 전역 에러와 도메인(비즈니스 로직)에 의한 오류 구분

**에러 핸들러 추가**

- 전역 에러 처리 클래스 추가 (restControllerAdvice)
  - 오류를 처리하는 위치를 분리하고, 클라이언트에게 오류의 종류를 명시해주기 위함.

**에러 검증(발생) 위치**

- 컨트롤러에서 요청 파라미터 검증
- db 엔티티 정합성 검증(엔티티가 존재하지 않음 등)
- 기타 비즈니스 로직 수행 중 발생하는 오류 검증 (재고 부족 등)

**안내사항**

- 동시에 온 여러 요청으로 인해 발생할 수 있는 오류는 작업하지 않음 (동시성 테스트 미진행)
- 비즈니스 로직 수행 중 발생하는 오류는 본 PR에서 작업하지 않음. 추후 테스트 작성하며 함께 추가 예정.
- db 엔티티 정합성 검증(엔티티가 존재하지 않음 등) 오류는 본 PR에서 작업하지 않음. 추후 동시성 테스트 작성하며 함께 추가 예정.

**고려사항**

> 커스텀 예외 vs 표준 예외

- 외부에서 발생하는 오류와 본 서비스에서 발생하는 오류를 구분하기 위하여 커스텀 예외를 사용함. 
- 단, 표준 예외를 상속하여 래핑한 정도로만 구현.
- 로깅할때도 더 유리할 것 같음 (추측임)

> 예외를 던지는 곳

- 도메인 객체 내부 (DTO, Entity 등)
- 데이터 정합성을 맞춰야 하는 곳

> 커스텀 예외에 포함해야 하는 값: 비즈니스 로직에서 처리하게 되는 예외도 HttpStatus를 가지게 하는 것이 좋은가? 불필요하지 않은가?

- 커스텀 예외에 HttpStatus도 포함되게 구현함
- 그런데 비즈니스 로직에서 try-catch로 처리할건데 HttpStatus도 포함하게 하는것이 불필요하지 않은가?
- 에러 클래스를 또 만들면 관리해야하는 포인트가 늘어남. 따라서 일단 HttpStatus도 가지는 예외 클래스를 이용함



**연관이슈**

resolves #26 